### PR TITLE
Update blink.c to correct negative value being returned to shell from wiringXsetup comparison

### DIFF
--- a/blink/blink.c
+++ b/blink/blink.c
@@ -8,7 +8,7 @@ int main() {
 
     if(wiringXSetup("duo", NULL) == -1) {
         wiringXGC();
-        return -1;
+        return 1;
     }
 
     if(wiringXValidGPIO(DUO_LED) != 0) {


### PR DESCRIPTION
POSIX 2.8.2 and 2.14, exit status must be unsigned decimal number. If the exit status is specified, but its value is not between 0 and 255 inclusively, the exit status is undefined. See https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html#tag_18_21