### PR TITLE
Improve adcRead.sh

### DIFF
--- a/adc/adcRead.sh
+++ b/adc/adcRead.sh
@@ -1,9 +1,17 @@
 #!/bin/sh
-saradc_path_cv180x=$(find / -name "cv180x_saradc.ko" 2>/dev/null)
-saradc_path_cv181x=$(find / -name "cv181x_saradc.ko" 2>/dev/null)
+search_exp="cv180x_saradc|cv181x_saradc"
 
-if (lsmod | grep -q "cv180x_saradc") || (lsmod | grep -q "cv181x_saradc") ;then
+if (lsmod | grep -qE $search_exp) ;then
         echo "SARADC module already loaded."
+else
+        saradc_path_cv180x=$(find / -name "cv180x_saradc.ko" 2>/dev/null)
+        saradc_path_cv181x=$(find / -name "cv181x_saradc.ko" 2>/dev/null)
+        insmod $saradc_path_cv180x >/dev/null
+        insmod $saradc_path_cv181x >/dev/null
+        echo "SARADC module loaded."
+fi
+
+if (lsmod | grep -qE $search_exp) ;then
         echo "Define the ADC channel:
                 1: ADC1 (GP26|PIN31)
                 2: ADC2 (GP27|PIN32)
@@ -17,34 +25,12 @@ if (lsmod | grep -q "cv180x_saradc") || (lsmod | grep -q "cv181x_saradc") ;then
                 echo "Enabling Channel $adc_channel"
                 echo $adc_channel > /sys/class/cvi-saradc/cvi-saradc0/device/cv_saradc
                 while true; do
-			echo "ADC $adc_channel read: $(cat /sys/class/cvi-saradc/cvi-saradc0/device/cv_saradc)"
-        		sleep 1
-		done
-	else
+                  echo "ADC $adc_channel read: $(cat /sys/class/cvi-saradc/cvi-saradc0/device/cv_saradc)"
+                  sleep 1
+                done
+        else
                 echo "Invalid ADC Channel."
         fi
-
 else
-        insmod $saradc_path_cv180x >/dev/null
-        insmod $saradc_path_cv181x >/dev/null
-        echo "SARADC module loaded."
-        echo "Define the ADC channel:
-                1: ADC1 (GP26|PIN31)
-                2: ADC2 (GP27|PIN32)
-                3: ???
-                4: VDDC_RTC
-                5: PWR_GPIO1
-                6: PWR_VBAT_"
-        read adc_channel
-
-        if [[ $adc_channel =~ ^[1-6]+$ ]]; then
-                echo "Enabling Channel $adc_channel"
-                echo $adc_channel > /sys/class/cvi-saradc/cvi-saradc0/device/cv_saradc
-               	while true; do
-			echo "ADC $adc_channel read: $(cat /sys/class/cvi-saradc/cvi-saradc0/device/cv_saradc)"
-        		sleep 1
-		done
-	else
-                echo "Invalid ADC Channel."
-        fi
+  echo "Could not load SARADC module."
 fi


### PR DESCRIPTION
Instead of running `find` upfront, which is slow, check if the module is loaded first, then search, and try to load, only if needed. This also checks that it was loaded, and shows an error if not. The UI code is de-duplicated too.